### PR TITLE
显著优化闪屏问题，增加m3u8链接自动获取

### DIFF
--- a/release/PKU-Art.user.js
+++ b/release/PKU-Art.user.js
@@ -10,8 +10,37 @@
 // @icon         https://cdn.arthals.ink/Arthals-mcskin.png
 // @namespace    https://github.com/zhuozhiyongde/PKU-Art
 // @supportURL   https://github.com/zhuozhiyongde/PKU-Art/issues
-// @updateURL    https://cdn.arthals.ink/release/PKU-Art.user.js
 // @date         2024/03/07
+// @downloadURL https://update.greasyfork.org/scripts/436323/PKU-Art.user.js
+// @updateURL https://update.greasyfork.org/scripts/436323/PKU-Art.meta.js
+// @resource main https://cdn.arthals.ink/css/main.css
+// @resource arco-palette https://cdn.arthals.ink/css/arco-palette.css
+// @resource iaaaOAuthPage https://cdn.arthals.ink/css/iaaaOAuthPage.css
+// @resource courseLoginPage https://cdn.arthals.ink/css/courseLoginPage.css
+// @resource courseHomePage https://cdn.arthals.ink/css/courseHomePage.css
+// @resource courseContent https://cdn.arthals.ink/css/courseContent.css
+// @resource courseAnnouncement https://cdn.arthals.ink/css/courseAnnouncement.css
+// @resource courseClassin https://cdn.arthals.ink/css/courseClassin.css
+// @resource courseBlankPage https://cdn.arthals.ink/css/courseBlankPage.css
+// @resource courseVideolist https://cdn.arthals.ink/css/courseVideolist.css
+// @resource courseOther https://cdn.arthals.ink/css/courseOther.css
+// @resource courseClassGrade https://cdn.arthals.ink/css/courseClassGrade.css
+// @resource courseListContent https://cdn.arthals.ink/css/courseListContent.css
+// @resource courseViewAttempt https://cdn.arthals.ink/css/courseViewAttempt.css
+// @resource courseToolFrame https://cdn.arthals.ink/css/courseToolFrame.css
+// @resource courseToolAlert https://cdn.arthals.ink/css/courseToolAlert.css
+// @resource courseToolGrade https://cdn.arthals.ink/css/courseToolGrade.css
+// @resource courseToolGradeClass https://cdn.arthals.ink/css/courseToolGradeClass.css
+// @resource courseToolGradeItem https://cdn.arthals.ink/css/courseToolGradeItem.css
+// @resource courseFileEmbed https://cdn.arthals.ink/css/courseFileEmbed.css
+// @resource courseAssignmentUpload https://cdn.arthals.ink/css/courseAssignmentUpload.css
+// @resource courseGlobalPage https://cdn.arthals.ink/css/courseGlobalPage.css
+// @resource courseGlobalAnnouncement https://cdn.arthals.ink/css/courseGlobalAnnouncement.css
+// @resource courseVideoPlay https://cdn.arthals.ink/css/courseVideoPlay.css
+// @resource courseVideoPlayFrame https://cdn.arthals.ink/css/courseVideoPlayFrame.css
+// @resource courseTask https://cdn.arthals.ink/css/courseTask.css
+// @grant GM_getResourceText
+// @grant GM_addStyle
 // ==/UserScript==
 (function () {
     'use strict';
@@ -20,265 +49,39 @@
 
 function injectPKUArt () {
     let htmlpath = location.href;
-    
-    if (/^https:\/\/iaaa\.pku\.edu\.cn\/\S*$|^https:\/\/course\.pku\.edu\.cn\/\S*$|^https:\/\/onlineroomse\.pku\.edu\.cn\/\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/main.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/main.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/main.css.");
-    }
-
-    if (/^https:\/\/iaaa\.pku\.edu\.cn\/\S*$|^https:\/\/course\.pku\.edu\.cn\/\S*$|^https:\/\/onlineroomse\.pku\.edu\.cn\/\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/arco-palette.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/arco-palette.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/arco-palette.css.");
-    }
-
-    if (/^https:\/\/iaaa\.pku\.edu\.cn\/\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/iaaaOAuthPage.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/iaaaOAuthPage.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/iaaaOAuthPage.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/login\S*$|^https:\/\/course\.pku\.edu\.cn[\/]?$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseLoginPage.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseLoginPage.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseLoginPage.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/?$|^https:\/\/course\.pku\.edu\.cn\/webapps\/portal\/\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseHomePage.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseHomePage.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseHomePage.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*course_id\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseContent.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseContent.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseContent.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/blackboard\S*announcement\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseAnnouncement.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseAnnouncement.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseAnnouncement.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*classinCourseClass\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseClassin.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseClassin.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseClassin.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*blankPage\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseBlankPage.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseBlankPage.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseBlankPage.css.");
-    }
-
-    if (/^https:\/\/course.pku.edu.cn\/webapps\S*videoList\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseVideolist.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseVideolist.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseVideolist.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*((discussionboard)|(groupContentList))\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseOther.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseOther.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseOther.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*myGrades\S*course_id\S*is_stream=false\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseClassGrade.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseClassGrade.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseClassGrade.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*listContent\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseListContent.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseListContent.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseListContent.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*viewAttempts\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseViewAttempt.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseViewAttempt.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseViewAttempt.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\S*toolId\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseToolFrame.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseToolFrame.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseToolFrame.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/streamViewer\/streamViewer\S*streamName=alerts\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseToolAlert.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseToolAlert.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseToolAlert.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/streamViewer\/streamViewer\S*streamName=mygrades\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseToolGrade.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseToolGrade.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseToolGrade.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*course_id\S*stream_name=mygrades$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseToolGradeClass.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseToolGradeClass.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseToolGradeClass.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*course_id\S*stream_name=mygrades_d\S*gradable_item_id\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseToolGradeItem.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseToolGradeItem.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseToolGradeItem.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*content\/file\?cmd=view\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseFileEmbed.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseFileEmbed.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseFileEmbed.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*assignment\/uploadAssignment\?\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseAssignmentUpload.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseAssignmentUpload.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseAssignmentUpload.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*context=mybb\S*$|^https:\/\/course\.pku\.edu\.cn\/webapps\/blackboard\/execute\/announcement$|^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*playVideo\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseGlobalPage.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseGlobalPage.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseGlobalPage.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*announcement\S*context=mybb\S*$|^https:\/\/course\.pku\.edu\.cn\/webapps\/blackboard\/execute\/announcement$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseGlobalAnnouncement.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseGlobalAnnouncement.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseGlobalAnnouncement.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*playVideo\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseVideoPlay.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseVideoPlay.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseVideoPlay.css.");
-    }
-
-    if (/^https:\/\/onlineroomse\.pku\.edu\.cn\/player\?course_id\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseVideoPlayFrame.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseVideoPlayFrame.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseVideoPlayFrame.css.");
-    }
-
-    if (/^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*taskView\S*$/.test(htmlpath)) {
-        let pkuartcss = document.createElement("link");
-        pkuartcss.href = 'https://cdn.arthals.ink/css/courseTask.css'
-        pkuartcss.rel = "stylesheet";
-        pkuartcss.className = "PKU-Art /css/courseTask.css";
-        pkuartcss.type = "text/css";
-        document.documentElement.appendChild(pkuartcss);
-        console.log("[PKU-Art] Injected https://cdn.arthals.ink/css/courseTask.css.");
+    const locationTest = [
+        {regex: /^https:\/\/iaaa\.pku\.edu\.cn\/\S*$|^https:\/\/course\.pku\.edu\.cn\/\S*$|^https:\/\/onlineroomse\.pku\.edu\.cn\/\S*$/, css: 'main'},
+        {regex: /^https:\/\/iaaa\.pku\.edu\.cn\/\S*$|^https:\/\/course\.pku\.edu\.cn\/\S*$|^https:\/\/onlineroomse\.pku\.edu\.cn\/\S*$/, css: 'arco-palette'},
+        {regex: /^https:\/\/iaaa\.pku\.edu\.cn\/\S*$/, css: 'iaaaOAuthPage'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/login\S*$|^https:\/\/course\.pku\.edu\.cn[\/]?$/, css: 'courseLoginPage'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/?$|^https:\/\/course\.pku\.edu\.cn\/webapps\/portal\/\S*$/, css: 'courseHomePage'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*course_id\S*$/, css: 'courseContent'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/blackboard\S*announcement\S*$/, css: 'courseAnnouncement'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*classinCourseClass\S*$/, css: 'courseClassin'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*blankPage\S*$/, css: 'courseBlankPage'},
+        {regex: /^https:\/\/course.pku.edu.cn\/webapps\S*videoList\S*$/, css: 'courseVideolist'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*((discussionboard)|(groupContentList))\S*$/, css: 'courseOther'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*myGrades\S*course_id\S*is_stream=false\S*$/, css: 'courseClassGrade'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*listContent\S*$/, css: 'courseListContent'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*viewAttempts\S*$/, css: 'courseViewAttempt'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\S*toolId\S*$/, css: 'courseToolFrame'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/streamViewer\/streamViewer\S*streamName=alerts\S*$/, css: 'courseToolAlert'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/streamViewer\/streamViewer\S*streamName=mygrades\S*$/, css: 'courseToolGrade'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*course_id\S*stream_name=mygrades$/, css: 'courseToolGradeClass'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*course_id\S*stream_name=mygrades_d\S*gradable_item_id\S*$/, css: 'courseToolGradeItem'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*content\/file\?cmd=view\S*$/, css: 'courseFileEmbed'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*assignment\/uploadAssignment\?\S*$/, css: 'courseAssignmentUpload'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*context=mybb\S*$|^https:\/\/course\.pku\.edu\.cn\/webapps\/blackboard\/execute\/announcement$|^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*playVideo\S*$/, css: 'courseGlobalPage'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*announcement\S*context=mybb\S*$|^https:\/\/course\.pku\.edu\.cn\/webapps\/blackboard\/execute\/announcement$/, css: 'courseGlobalAnnouncement'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*playVideo\S*$/, css: 'courseVideoPlay'},
+        {regex: /^https:\/\/onlineroomse\.pku\.edu\.cn\/player\?course_id\S*$/, css: 'courseVideoPlayFrame'},
+        {regex: /^https:\/\/course\.pku\.edu\.cn\/webapps\/\S*taskView\S*$/, css: 'courseTask'}
+    ]
+    for (let i = 0; i < locationTest.length; i++) {
+        if (locationTest[i].regex.test(htmlpath)) {
+            GM_addStyle(GM_getResourceText(locationTest[i].css));
+            console.log('[PKU Art] Injected ' + locationTest[i].css + ' at ' + new Date().toLocaleString());
+        }
     }
 
 }
@@ -409,6 +212,26 @@ function injectPKUArt () {
     downloadUrlButton.parentNode.insertBefore(downloadUrlInput, downloadUrlButton.nextSibling);
 
     console.log('Injected downloadUrlInput');
+
+    // 自动获取m3u8链接 2024/03/23
+    const originOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function (_, url) {
+        if (url.includes(".m3u8")) {
+            const xhr = this;
+            document.querySelector('#injectDownloadUrlInput').value = url;
+            const getter = Object.getOwnPropertyDescriptor(
+                XMLHttpRequest.prototype,
+                "response"
+            ).get;
+            Object.defineProperty(xhr, "responseText", {
+                get: () => {
+                    let result = getter.call(xhr);
+                    return result;
+                },
+            });
+        }
+        originOpen.apply(this, arguments);
+    };
 
     // 重新获取 downloadApp
     downloadApp = document.querySelector(


### PR DESCRIPTION
仅修改了油猴用户脚本：
1.使用油猴提供的外置静态资源接口，支持预加载，显著减少闪屏现象，并让代码显得稍微好看了一点。
（经测试firefox明显减少闪屏时间，edge可以做到几乎不闪屏）
2.课程录播下载：使用XHR请求拦截器主动获取m3u8链接，无需先复制再手动粘贴